### PR TITLE
Changed the max handles to the proper max of uint16 so it does not wr…

### DIFF
--- a/src/include/libks/internal/ks_handle.h
+++ b/src/include/libks/internal/ks_handle.h
@@ -29,7 +29,7 @@ KS_BEGIN_EXTERN_C
  * tracking structures across ks are all small fixed sized items.
  */
 #define KS_HANDLE_MAX_SIZE 		512
-#define KS_HANDLE_MAX_SLOTS 	65536 	/* max value of uint16_t */
+#define KS_HANDLE_MAX_SLOTS 	65535 	/* max value of uint16_t */
 #define KS_HANDLE_MAX_GROUPS	20
 
 #define KS_HANDLE_MAX_NOTREADY_WAIT_MS	(30 * 1000)	/* Wait 30 seconds before considering a hung not ready call */

--- a/src/ks_handle.c
+++ b/src/ks_handle.c
@@ -128,7 +128,7 @@ static inline ks_status_t __reserve_slot(ks_handle_group_t *group,
 
 	/* Try again at zero if we couldn't find one at the hint
 	 * (Always start at 1, 0 is invalid) */
-	if (start_index) {
+	if (start_index > 1) {
 		return __reserve_slot(group, 1, found_index, found_slot);
 	}
 


### PR DESCRIPTION
…ap in __reserve_slot

Also changed it to only call recursively when it was intended with start_index > 1

This should resolve https://gist.github.com/emcgee/52496cf268b732b6e9da106f2a3ec729