### PR TITLE
Fix wrong printf format specifier (use %u instead of %lu for uint32_t).

### DIFF
--- a/src/ks_thread.c
+++ b/src/ks_thread.c
@@ -25,7 +25,7 @@
 #include "libks/internal/ks_thread.h"
 
 /* Keep some basic counters for some basic debugging info when needed */
-static uint32_t g_active_detached_thread_count, g_active_attached_thread_count;
+static uint32_t g_active_detached_thread_count = 0, g_active_attached_thread_count = 0;
 
 /* Define the max number of seconds we'll wait for the thread to set its state to ready */
 #define KS_THREAD_SANITY_WAIT_MS 1000
@@ -644,7 +644,7 @@ KS_DECLARE(void) ks_thread_destroy(ks_thread_t **threadp)
 	pthread_attr_destroy(&thread->attribute);
 #endif
 
-	ks_log(KS_LOG_DEBUG, "Current active and attached count: %lu, current active and detatched count: %lu\n",
+	ks_log(KS_LOG_DEBUG, "Current active and attached count: %u, current active and detatched count: %u\n",
 		g_active_attached_thread_count, g_active_detached_thread_count);
 
 	if (detached) {
@@ -767,7 +767,7 @@ KS_DECLARE(ks_status_t) __ks_thread_create_ex(
 		ks_atomic_increment_uint32(&g_active_attached_thread_count);
 	}
 
-	ks_log(KS_LOG_DEBUG, "Allocating new thread, current active and attached count: %lu, current active and detatched count: %lu\n",
+	ks_log(KS_LOG_DEBUG, "Allocating new thread, current active and attached count: %u, current active and detatched count: %u\n",
 		g_active_attached_thread_count, g_active_detached_thread_count);
 
 	thread->private_data = data;


### PR DESCRIPTION
Should fix this:
```
==26996== Use of uninitialised value of size 8
==26996==    at 0x8666EDB: _itoa_word (in /usr/lib64/libc-2.17.so)
==26996==    by 0x8667F55: vfprintf (in /usr/lib64/libc-2.17.so)
==26996==    by 0x8693EE2: vasprintf (in /usr/lib64/libc-2.17.so)
==26996==    by 0x11CB5E19: ks_log (ks_log.c:454)
==26996==    by 0x11CBFE8C: __ks_thread_create_ex (ks_thread.c:771)
==26996==    by 0x16EEE514: swclt_hmgr_init (handle_manager.c:287)
==26996==    by 0x16EF054D: swclt_init (init.c:34)
==26996==    by 0x11A892A4: mod_signalwire_load (mod_signalwire.c:865)
==26996==    by 0x547D7C6: switch_loadable_module_load_file (switch_loadable_module.c:1487)
==26996==    by 0x547D7C6: switch_loadable_module_load_module_ex (switch_loadable_module.c:1595)
==26996==    by 0x548054C: switch_loadable_module_init (switch_loadable_module.c:1905)
==26996==    by 0x543E857: switch_core_init_and_modload (switch_core.c:2454)
==26996==    by 0x402EE3: main (switch.c:1181)
```