### PR TITLE
Added a kws_create to use before calling kws_connect or kws_init, if …

### DIFF
--- a/src/include/libks/kws.h
+++ b/src/include/libks/kws.h
@@ -66,6 +66,7 @@ KS_DECLARE(ks_ssize_t) kws_raw_read(kws_t *kws, void *data, ks_size_t bytes, int
 KS_DECLARE(ks_ssize_t) kws_raw_write(kws_t *kws, void *data, ks_size_t bytes);
 KS_DECLARE(ks_status_t) kws_init(kws_t **kwsP, ks_socket_t sock, SSL_CTX *ssl_ctx, const char *client_data, kws_flag_t flags, ks_pool_t *pool);
 KS_DECLARE(ks_ssize_t) kws_close(kws_t *kws, int16_t reason);
+KS_DECLARE(ks_status_t) kws_create(kws_t **kwsP, ks_pool_t *pool);
 KS_DECLARE(void) kws_destroy(kws_t **kwsP);
 KS_DECLARE(ks_status_t) kws_connect(kws_t **kwsP, ks_json_t *params, kws_flag_t flags, ks_pool_t *pool);
 KS_DECLARE(ks_status_t) kws_connect_ex(kws_t **kwsP, ks_json_t *params, kws_flag_t flags, ks_pool_t *pool, SSL_CTX *ssl_ctx, uint32_t timeout_ms);

--- a/src/kws.c
+++ b/src/kws.c
@@ -746,7 +746,9 @@ KS_DECLARE(ks_status_t) kws_init(kws_t **kwsP, ks_socket_t sock, SSL_CTX *ssl_ct
 {
 	kws_t *kws;
 
-	kws = ks_pool_alloc(pool, sizeof(*kws));
+	if (*kwsP) kws = *kwsP;
+	else kws = ks_pool_alloc(pool, sizeof(*kws));
+
 	kws->flags = flags;
 	kws->unprocessed_buffer_len = 0;
 	kws->unprocessed_position = NULL;
@@ -837,6 +839,16 @@ KS_DECLARE(ks_status_t) kws_init(kws_t **kwsP, ks_socket_t sock, SSL_CTX *ssl_ct
 	kws_destroy(&kws);
 
 	return KS_STATUS_FAIL;
+}
+
+KS_DECLARE(ks_status_t) kws_create(kws_t **kwsP, ks_pool_t *pool)
+{
+	kws_t *kws;
+
+	kws = ks_pool_alloc(pool, sizeof(*kws));
+	*kwsP = kws;
+
+	return KS_STATUS_SUCCESS;
 }
 
 KS_DECLARE(void) kws_destroy(kws_t **kwsP)


### PR DESCRIPTION
…allocated when passed to kws_connect or kws_init then it will use the existing kws object, this allows to assign callbacks or other values before calling connect