### PR TITLE
Fix changelog when packaging for Debian.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,11 +284,35 @@ if("${CMAKE_OS_NAME}" STREQUAL "Debian")
 	# Generate a Debian compliant changelog
 	if(GIT_FOUND AND GZIP_CMD AND DATE_CMD)
 		# Get git log info
-		execute_process(COMMAND ${GIT_EXECUTABLE} log --no-merges --pretty=format:"%n  [%an]%n   * %s" --since="last month"
+		message("Detecting last git tag to generate a Debian complian changelog.")
+		execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0
+			OUTPUT_VARIABLE LAST_TAG
+			WORKING_DIRECTORY .
+			OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+		# Commits count since last tag
+		execute_process(COMMAND ${GIT_EXECUTABLE} rev-list ${LAST_TAG}.. --count
+			OUTPUT_VARIABLE COMMITS_COUNT_SINCE_LAST_TAG
+			WORKING_DIRECTORY .
+			OUTPUT_STRIP_TRAILING_WHITESPACE)
+		message("Found last git tag: ${LAST_TAG}")
+
+		# Check if we have commits since last tag
+		if (COMMITS_COUNT_SINCE_LAST_TAG STREQUAL "0")
+			# if not, find second tag so we could have a changelog
+			message("No commits since git tag '${LAST_TAG}' to generate a changelog, looking for a previous tag")
+			execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0 ${LAST_TAG}^
+				OUTPUT_VARIABLE LAST_TAG
+				WORKING_DIRECTORY .
+				OUTPUT_STRIP_TRAILING_WHITESPACE)
+		endif()
+
+		message("Generating a changelog using commits since git tag: ${LAST_TAG}")
+		execute_process(COMMAND ${GIT_EXECUTABLE} log --no-merges --pretty=format:"%n  [%an]%n   * %s" ${LAST_TAG}..HEAD
 			OUTPUT_VARIABLE CHANGELOG
 			WORKING_DIRECTORY .
 			OUTPUT_STRIP_TRAILING_WHITESPACE)
-		string(REPLACE "\"" "" CHANGELOG "${CHANGELOG}")
+		string(REPLACE "\"" "" CHANGELOG ${CHANGELOG})
 
 		# Create changelog
 		file(WRITE changelog.Debian ${CHANGELOG_HEADER}\n${CHANGELOG}\n\n${CHANGELOG_FOOTER})


### PR DESCRIPTION
This PR deprecates this temporary change: https://github.com/signalwire/libks/commit/a78a3aef54482eea738eff9ce0d9cbf8b9c0fe4d#diff-af3b638bc2a3e6c650974192a53c7291