### PR TITLE
Install CentOS shared libraries to /usr/lib64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 # Fixes build on older gcc, Debian Jessie
 if(KS_PLAT_LIN)
 	set(CMAKE_C_STANDARD 99)
+	include(GNUInstallDirs)
 endif()
 
 if (KS_PLAT_WIN OR WITH_KS_TEST)
@@ -58,7 +59,7 @@ endif()
 # us to run the apps from the build dir without installing (come install time
 # the binary is re-linked with an rpath matching that of the install prefix)
 set(SKIP_BUILD_RPATH TRUE)
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 
 # Now detect a bunch of platform stuff
 include(CheckFunctionExists)
@@ -105,6 +106,10 @@ endif()
 
 # Centos packaging
 if("${CMAKE_OS_NAME}" STREQUAL "Centos")
+
+	# Install shared libraries to /usr/lib64
+	set(CMAKE_INSTALL_LIBDIR lib64 CACHE PATH "Library installation location" FORCE)
+	set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 
 	# Enable component install
 	set(CPACK_RPM_COMPONENT_INSTALL ON)
@@ -558,7 +563,7 @@ export(TARGETS ks
 if (NOT KS_PLAT_WIN)
 
 	# Set install targets
-	install(TARGETS ks COMPONENT "runtime" EXPORT LibKSConfig DESTINATION lib)
+	install(TARGETS ks COMPONENT "runtime" EXPORT LibKSConfig DESTINATION ${CMAKE_INSTALL_LIBDIR})
 	install(DIRECTORY src/include/libks COMPONENT "runtime" DESTINATION include PATTERN src/include/libks/internal EXCLUDE)
 
 	# Set path for pkg-config based on ARCH and distro type

--- a/libks.pc.in
+++ b/libks.pc.in
@@ -1,6 +1,6 @@
 prefix=@PC_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/lib
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 definitions=@PC_DEFINITIONS@
 


### PR DESCRIPTION
For CentOS install shared libraries to /usr/lib64. Adjust pkgconfig metadata accordingly.

The thing that surprises me is CMAKE_INSTALL_LIBDIR is set by cmake to lib instead of lib64 under CentOS. This is manually fixed in the PR.