### PR TITLE
Fix CRYPTO_MEM_CHECK_ON undefined

### DIFF
--- a/src/ks_ssl.c
+++ b/src/ks_ssl.c
@@ -131,7 +131,9 @@ KS_DECLARE(int) ks_gen_cert(const char *dir, const char *file)
 		rsa = ks_mprintf("%s%s%s.crt", dir, KS_PATH_SEPARATOR, file);
 	}
 
+#ifdef CRYPTO_MEM_CHECK_ON
 	CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ON);
+#endif
 
 	//bio_err=BIO_new_fp(stderr, BIO_NOCLOSE);
 


### PR DESCRIPTION
CRYPTO_MEM_CHECK_ON still exists in OpenSSL 3.x,
but is now inside ifndef OPENSSL_NO_CRYPTO_MDEBUG
So it exists only in debug builds.
Probably the right fix is to just add
ifdef CRYPTO_MEM_CHECK_ON around code that tries to use it.
https://github.com/mumble-voip/mumble/issues/4266