### PR TITLE
Json logging option

### DIFF
--- a/src/include/libks/ks_log.h
+++ b/src/include/libks/ks_log.h
@@ -32,8 +32,6 @@ KS_DECLARE(ks_size_t) ks_log_format_output(char *buf, ks_size_t bufSize, const c
 KS_DECLARE(int) ks_log_level_by_name(const char *name);
 /*! Sets the logger for libks. Default is the null_logger */
 KS_DECLARE(void) ks_global_set_logger(ks_logger_t logger);
-/*! Sets the default log level for libks */
-KS_DECLARE(void) ks_global_set_default_logger(int level);
 /*! Sets the default log prefix for libks */
 KS_DECLARE(void) ks_global_set_default_logger_prefix(ks_log_prefix_t prefix);
 /*! Sets the global console log level */

--- a/src/include/libks/ks_log.h
+++ b/src/include/libks/ks_log.h
@@ -23,6 +23,9 @@
 
 KS_BEGIN_EXTERN_C
 
+KS_DECLARE(void) ks_log_init(void);
+KS_DECLARE(void) ks_log_shutdown(void);
+
 KS_DECLARE(void) ks_log(const char *file, const char *func, int line, int level, const char *fmt, ...);
 
 KS_DECLARE(ks_size_t) ks_log_format_output(char *buf, ks_size_t bufSize, const char *file, const char *func, int line, int level, const char *fmt, va_list ap);
@@ -35,12 +38,6 @@ KS_DECLARE(void) ks_global_set_logger(ks_logger_t logger);
 KS_DECLARE(void) ks_global_set_default_logger_prefix(ks_log_prefix_t prefix);
 /*! Sets the global console log level */
 KS_DECLARE(void) ks_global_set_log_level(int level);
-/*! Sets the global file log level */
-KS_DECLARE(void) ks_global_set_file_log_level(int level);
-/*! Opens the global file log */
-KS_DECLARE(ks_bool_t) ks_global_set_file_log_path(const char *path);
-/*! Closes the global file log */
-KS_DECLARE(void) ks_global_close_file_log();
 /*! Enable json based log output */
 KS_DECLARE(void) ks_log_jsonify(void);
 /*! Sanitizes output strings */

--- a/src/include/libks/ks_log.h
+++ b/src/include/libks/ks_log.h
@@ -42,6 +42,8 @@ KS_DECLARE(void) ks_global_set_file_log_level(int level);
 KS_DECLARE(ks_bool_t) ks_global_set_file_log_path(const char *path);
 /*! Closes the global file log */
 KS_DECLARE(void) ks_global_close_file_log();
+/*! Enable json based log output */
+KS_DECLARE(void) ks_log_jsonify(void);
 /*! Sanitizes output strings */
 KS_DECLARE(void) ks_log_sanitize_string(char *str);
 

--- a/src/include/libks/ks_log.h
+++ b/src/include/libks/ks_log.h
@@ -25,7 +25,6 @@ KS_BEGIN_EXTERN_C
 
 KS_DECLARE(void) ks_log(const char *file, const char *func, int line, int level, const char *fmt, ...);
 
-KS_DECLARE(const char *) ks_log_console_color(int level);
 KS_DECLARE(ks_size_t) ks_log_format_output(char *buf, ks_size_t bufSize, const char *file, const char *func, int line, int level, const char *fmt, va_list ap);
 
 /*! Gets the log level from a string name, returns -1 if invalid */

--- a/src/ks.c
+++ b/src/ks.c
@@ -51,6 +51,7 @@ KS_DECLARE(ks_status_t) ks_init(void)
 #endif
 
 	ks_time_init();
+	ks_log_init();
 
 #ifdef __WINDOWS__
 	pid = _getpid();
@@ -97,11 +98,11 @@ KS_DECLARE(ks_status_t) ks_shutdown(void)
 		status = ks_pool_close(&g_pool);
 	}
 
+	ks_log_shutdown();
+
 done:
 
 	ks_spinlock_release(&g_init_lock);
-
-	ks_global_close_file_log();
 
 	return status;
 }

--- a/src/ks_log.c
+++ b/src/ks_log.c
@@ -315,10 +315,13 @@ static void default_logger(const char *file, const char *func, int line, int lev
 			ks_json_t *json = ks_json_create_object();
 			ks_json_add_string_to_object(json, "message", buf); // Can ignore prefix len since color is disabled if jsonified
 			char *tmp = ks_json_print_unformatted(json);
-			strncpy(buf, tmp, sizeof(buf) - 1); // safe truncation if neccessary
-			buf[sizeof(buf)] = 0;
+			strncpy(buf, tmp, sizeof(buf) - 2); // safe truncation if neccessary, leaving 2 bytes for newline and terminator
+			buf[sizeof(buf)] = 0; // gaurentee temporary termination if strncpy used all the data
 			len = strlen(buf); // reassign len, which is used for both console and file output length
-			free(tmp);
+			buf[len] = '\n'; // add a newline to each json output
+			buf[len + 1] = '\0'; // fix the null term we just replaced
+			++len; // add the new line character to the output length
+			free(tmp); // cleanup
 			ks_json_delete(&json);
 		}
 

--- a/src/ks_log.c
+++ b/src/ks_log.c
@@ -255,7 +255,7 @@ static void default_logger(const char *file, const char *func, int line, int lev
 
 	if (ks_log_jsonified) {
 		char *data = NULL;
-		int ret = ks_vasprintf(&data, fmt, ap);
+		ks_vasprintf(&data, fmt, ap);
 		len = strlen(data);
 		if (len > 0) {
 			char tbuf[256];

--- a/src/ks_log.c
+++ b/src/ks_log.c
@@ -379,7 +379,7 @@ KS_DECLARE(void) ks_log_jsonify(void)
 
 KS_DECLARE(void) ks_log_init(void)
 {
-	ks_mutex_create(&g_log_mutex, KS_MUTEX_FLAG_DEFAULT, NULL);
+	ks_mutex_create(&g_log_mutex, KS_MUTEX_FLAG_DEFAULT | KS_MUTEX_FLAG_RAW_ALLOC, NULL);
 }
 
 KS_DECLARE(void) ks_log_shutdown(void)

--- a/tests/testhash.c
+++ b/tests/testhash.c
@@ -183,7 +183,7 @@ int main(int argc, char **argv)
 {
 
 	ks_init();
-	ks_global_set_default_logger(KS_LOG_LEVEL_DEBUG);
+	ks_global_set_log_level(KS_LOG_LEVEL_DEBUG);
 
 	plan(3);
 

--- a/tests/testlog.c
+++ b/tests/testlog.c
@@ -30,7 +30,7 @@ int main(int argc, char **argv)
 	memset(a, 'a', sizeof(a));
 	a[sizeof(a) - 1] = '\0';
 	ks_init();
-	ks_global_set_default_logger(KS_LOG_LEVEL_DEBUG);
+	ks_global_set_log_level(KS_LOG_LEVEL_DEBUG);
 	ks_log(a, a, 9999999, KS_LOG_LEVEL_DEBUG, a);
 	ks_log(a, a, 9999999, KS_LOG_LEVEL_INFO, a);
 	ks_log(a, a, 9999999, KS_LOG_LEVEL_WARNING, a);

--- a/tests/testwebsock2.c
+++ b/tests/testwebsock2.c
@@ -348,6 +348,7 @@ int main(int argc, char *argv[])
 	char *url = NULL;
 
 	ks_init();
+	ks_log_jsonify();
 
 	plan(3);
 

--- a/tests/testwebsock2.c
+++ b/tests/testwebsock2.c
@@ -306,7 +306,7 @@ static int test_ws(char *url)
 	ks_json_t *req = ks_json_create_object();
 	ks_json_add_string_to_object(req, "url", url);
 
-	ks_global_set_default_logger(7);
+	ks_global_set_log_level(7);
 
 	ks_pool_open(&pool);
 	ks_assert(pool);


### PR DESCRIPTION
This is only the bare minimum, it creates a json object and plants the existing output into the message field, and removes the color coding.
This can be evolved to include more fields into the json object as appropriate, but will require a bit more tuning of the logging system to enable adding keys from ks_log calls, best left for another issue as this satisfies the base requirements.