### PR TITLE
Cflags should point to include folder, not to include/libks

### DIFF
--- a/libks.pc.in
+++ b/libks.pc.in
@@ -8,5 +8,5 @@ Name: @PACKAGE_NAME@
 Version: @PACKAGE_VERSION@
 Description: A cross platform kitchen sink library.
 
-Cflags: -I${includedir}/libks
+Cflags: -I${includedir}
 Libs: -L${libdir} -lks


### PR DESCRIPTION
Since all headers include as "libks/ks.h", cflags should point to just <prefix>/include, not to the <prefix>/include/libks. In current mode with libks in cflags in pkg-config files must be referenced simply as "ks.h".