### PR TITLE
Queue peek

### DIFF
--- a/README
+++ b/README
@@ -41,3 +41,5 @@ make install
 Centos dependencies:
 - yum groupinstall "Development Tools"
 - yum install libuuid-devel libatomic openssl-devel
+
+#ignore this

--- a/README
+++ b/README
@@ -42,4 +42,3 @@ Centos dependencies:
 - yum groupinstall "Development Tools"
 - yum install libuuid-devel libatomic openssl-devel
 
-#ignore this

--- a/src/include/libks/ks_q.h
+++ b/src/include/libks/ks_q.h
@@ -41,6 +41,7 @@ KS_DECLARE(ks_status_t) ks_q_push(ks_q_t *q, void *ptr);
 KS_DECLARE(ks_status_t) ks_q_trypush(ks_q_t *q, void *ptr);
 KS_DECLARE(ks_status_t) ks_q_pop(ks_q_t *q, void **ptr);
 KS_DECLARE(ks_status_t) ks_q_trypop(ks_q_t *q, void **ptr);
+KS_DECLARE(ks_status_t) ks_q_trypeek(ks_q_t *q, void **ptr);
 
 KS_END_EXTERN_C
 

--- a/src/ks_q.c
+++ b/src/ks_q.c
@@ -342,6 +342,28 @@ static ks_status_t do_pop(ks_q_t *q, void **ptr)
 	return KS_STATUS_SUCCESS;
 }
 
+static ks_status_t do_peek(ks_q_t *q, void **ptr)
+{
+	ks_qnode_t *np;
+
+	ks_mutex_lock(q->list_mutex);
+
+	if (!q->active) {
+		ks_mutex_unlock(q->list_mutex);
+		return KS_STATUS_INACTIVE;
+	}
+
+	if (!q->head) {
+		*ptr = NULL;
+	} else {
+		np = q->head;
+		*ptr = np->ptr;
+	}
+	ks_mutex_unlock(q->list_mutex);
+
+	return KS_STATUS_SUCCESS;
+}
+
 KS_DECLARE(ks_status_t) ks_q_pop_timeout(ks_q_t *q, void **ptr, uint32_t timeout)
 {
 	ks_status_t r;
@@ -418,6 +440,32 @@ KS_DECLARE(ks_status_t) ks_q_trypop(ks_q_t *q, void **ptr)
 	if (q->pushers) {
 		ks_cond_signal(q->push_cond);
 	}
+
+ end:
+
+	ks_mutex_unlock(q->list_mutex);
+
+	return r;
+
+}
+
+KS_DECLARE(ks_status_t) ks_q_trypeek(ks_q_t *q, void **ptr)
+{
+	ks_status_t r;
+
+	ks_mutex_lock(q->list_mutex);
+
+	if (!q->active) {
+		r = KS_STATUS_INACTIVE;
+		goto end;
+	}
+
+	if (q->len == 0) {
+		r = KS_STATUS_BREAK;
+		goto end;
+	}
+
+	r = do_peek(q, ptr);
 
  end:
 

--- a/src/ks_thread_pool.c
+++ b/src/ks_thread_pool.c
@@ -244,7 +244,7 @@ KS_DECLARE(ks_status_t) ks_thread_pool_destroy(ks_thread_pool_t **tp)
 	while ((itt = ks_hash_first((*tp)->thread_hash, KS_UNLOCKED))) {
 		void *key;
 
-		ks_hash_this(itt, &key, NULL, NULL);
+		ks_hash_this(itt, (const void **)&key, NULL, NULL);
 		ks_thread_join((ks_thread_t*)key);
 		ks_hash_remove((*tp)->thread_hash, key);
 		ks_thread_destroy((ks_thread_t**)&key);

--- a/tests/testq.c
+++ b/tests/testq.c
@@ -216,6 +216,28 @@ ks_size_t qtest2(int ttl, int try, int loops)
 
 }
 
+ks_status_t qtest3()
+{
+	ks_q_t *q = NULL;
+	ks_pool_t *pool = NULL;
+	ks_status_t status = KS_STATUS_SUCCESS;
+
+	ks_pool_open(&pool);
+	ks_q_create(&q, pool, 0);
+
+	int *val = (int*)ks_pool_alloc(pool, sizeof(int));
+	int *tmp = NULL;
+
+	if ((status = ks_q_trypeek(q, (void **)&tmp)) != KS_STATUS_BREAK) return KS_STATUS_FAIL;
+	if ((status = ks_q_trypush(q, val)) != KS_STATUS_SUCCESS) return status;
+	if (ks_q_size(q) != 1) return KS_STATUS_FAIL;
+	if (ks_q_trypeek(q, (void **)&tmp) != KS_STATUS_SUCCESS) return KS_STATUS_FAIL;
+	if (tmp != val) return KS_STATUS_FAIL;
+	if (ks_q_size(q) != 1) return KS_STATUS_FAIL;
+
+	ks_q_destroy(&q);
+	ks_pool_close(&pool);
+}
 
 int main(int argc, char **argv)
 {
@@ -232,6 +254,7 @@ int main(int argc, char **argv)
 	//ttl = 5;
 
 
+	ok(qtest3() == KS_STATUS_SUCCESS);
 	for(i = 0; i < runs; i++) {
 		ok(qtest1(size));
 		ok(qtest2(ttl, 0, size) == 0);

--- a/tests/testq.c
+++ b/tests/testq.c
@@ -248,7 +248,7 @@ int main(int argc, char **argv)
 
 	ks_init();
 
-	plan(4 * runs);
+	plan(4 * runs + 1);
 
 	ttl = ks_env_cpu_count() * 5;
 	//ttl = 5;


### PR DESCRIPTION
Add ks_q_trypeek to look at an item without removing it, this helps supporting a use case where queues are used to track expiring information