### PR TITLE
CMakeList.txt: correct location of «copyright» file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -577,7 +577,7 @@ if (NOT KS_PLAT_WIN)
 	install(FILES cmake/FindConfig.cmake COMPONENT "runtime" DESTINATION include/libks/cmake)
 	install(FILES cmake/FindConfigCpp.cmake COMPONENT "runtime" DESTINATION include/libks/cmake)
 	install(FILES cmake/AddLibBacktrace.cmake COMPONENT "runtime" DESTINATION include/libks/cmake)
-	install(FILES ${PROJECT_BINARY_DIR}/copyright COMPONENT "runtime" DESTINATION share/doc/libks)
+	install(FILES ${PROJECT_SOURCE_DIR}/copyright COMPONENT "runtime" DESTINATION share/doc/libks)
 	install(EXPORT LibKSConfig COMPONENT "runtime" DESTINATION include/libks/cmake)
 
 	# Set uninstall target


### PR DESCRIPTION
Otherwise out-of-source builds do not work