### PR TITLE
Quieter kws close

### DIFF
--- a/src/kws.c
+++ b/src/kws.c
@@ -1222,7 +1222,7 @@ KS_DECLARE(ks_ssize_t) kws_read_frame(kws_t *kws, kws_opcode_t *oc, uint8_t **da
 	switch(*oc) {
 	case WSOC_CLOSE:
 		{
-			ks_log(KS_LOG_ERROR, "Read frame error because OPCODE = WSOC_CLOSE\n");
+			ks_log(KS_LOG_DEBUG, "Read frame OPCODE = WSOC_CLOSE\n");
 			kws->plen = kws->buffer[1] & 0x7f;
 			*data = (uint8_t *) &kws->buffer[2];
 			return kws_close(kws, WS_RECV_CLOSE);

--- a/src/kws.c
+++ b/src/kws.c
@@ -1222,7 +1222,7 @@ KS_DECLARE(ks_ssize_t) kws_read_frame(kws_t *kws, kws_opcode_t *oc, uint8_t **da
 	switch(*oc) {
 	case WSOC_CLOSE:
 		{
-			// Nominal case, debug output only
+			/* Nominal case, debug output only */
 			ks_log(KS_LOG_DEBUG, "Read frame OPCODE = WSOC_CLOSE\n");
 			kws->plen = kws->buffer[1] & 0x7f;
 			*data = (uint8_t *) &kws->buffer[2];

--- a/src/kws.c
+++ b/src/kws.c
@@ -1222,6 +1222,7 @@ KS_DECLARE(ks_ssize_t) kws_read_frame(kws_t *kws, kws_opcode_t *oc, uint8_t **da
 	switch(*oc) {
 	case WSOC_CLOSE:
 		{
+			// Nominal case, debug output only
 			ks_log(KS_LOG_DEBUG, "Read frame OPCODE = WSOC_CLOSE\n");
 			kws->plen = kws->buffer[1] & 0x7f;
 			*data = (uint8_t *) &kws->buffer[2];


### PR DESCRIPTION
Adjusted the log output from an error to debug for when KWS reads a nominal frame containing the opcode to CLOSE the websocket.