### PR TITLE
Resolve warnings on debian stable

### DIFF
--- a/src/kws.c
+++ b/src/kws.c
@@ -176,12 +176,16 @@ static int b64encode(unsigned char *in, ks_size_t ilen, unsigned char *out, ks_s
 
 static void sha1_digest(unsigned char *digest, char *in)
 {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
+	SHA1(in, strlen(in), digest);
+#else
 	SHA_CTX sha;
 
 	SHA1_Init(&sha);
 	SHA1_Update(&sha, in, strlen(in));
 	SHA1_Final(digest, &sha);
 
+#endif
 }
 
 /* fix me when we get real rand funcs in ks */

--- a/src/simclist.c
+++ b/src/simclist.c
@@ -1354,7 +1354,7 @@ int ks_list_dump_filedescriptor(const ks_list_t *restrict l, int fd, ks_size_t *
 					WRITE_ERRCHECK(fd, ser_buf, bufsize);
 				}
 				else {                        /* speculation found broken */
-					WRITE_ERRCHECK(fd, &bufsize, sizeof(ks_size_t));
+					WRITE_ERRCHECK(fd, &bufsize, sizeof(uint32_t));
 					WRITE_ERRCHECK(fd, ser_buf, bufsize);
 				}
 				ks_pool_free(&ser_buf);
@@ -1379,7 +1379,7 @@ int ks_list_dump_filedescriptor(const ks_list_t *restrict l, int fd, ks_size_t *
 					WRITE_ERRCHECK(fd, x->data, bufsize);
 				}
 				else {
-					WRITE_ERRCHECK(fd, &bufsize, sizeof(ks_size_t));
+					WRITE_ERRCHECK(fd, &bufsize, sizeof(uint32_t));
 					WRITE_ERRCHECK(fd, x->data, bufsize);
 				}
 			}

--- a/tests/testwebsock2.c
+++ b/tests/testwebsock2.c
@@ -97,11 +97,15 @@ static void sha1_digest(char *digest, unsigned char *in)
 
 static void sha1_digest(unsigned char *digest, char *in)
 {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000
+	SHA1(in, strlen(in), digest);
+#else
 	SHA_CTX sha;
 
 	SHA1_Init(&sha);
 	SHA1_Update(&sha, in, strlen(in));
 	SHA1_Final(digest, &sha);
+#endif
 }
 #endif
 


### PR DESCRIPTION
Primarily updated to use non-deprecated OpenSSL types and functions when available. Also fixed a warning about `write(2)` reading too many bytes from the source buffer.

Fixes #158 #169 