### PR TITLE
WebSockets: move assert out of the loop in kws_read_frame()

### DIFF
--- a/src/kws.c
+++ b/src/kws.c
@@ -1465,8 +1465,9 @@ KS_DECLARE(ks_ssize_t) kws_read_frame(kws_t *kws, kws_opcode_t *oc, uint8_t **da
 				memcpy(kws->body, kws->payload, kws->rplen);
 			}
 
+			ks_assert((kws->body + kws->plen) <= (kws->bbuffer + kws->bbuflen));
+
 			while(need) {
-				ks_assert((kws->body + need + kws->rplen) <= (kws->bbuffer + kws->bbuflen));
 				ks_ssize_t r = kws_string_read(kws, kws->body + kws->rplen, need + 1, WS_BLOCK);
 
 				if (r < 1) {


### PR DESCRIPTION
Since `kws->rplen = kws->plen - need;` then `kws->plen` is the same as `need + kws->rplen` we can move the assert out of the loop.