### PR TITLE
Fix return from kws_raw_write on fragmented frame sending

### DIFF
--- a/src/kws.c
+++ b/src/kws.c
@@ -650,7 +650,7 @@ KS_DECLARE(ks_ssize_t) kws_raw_write(kws_t *kws, void *data, ks_size_t bytes)
 		//printf("wRITE FAIL: %s\n", strerror(errno));
 	//}
 
-	return r > 0 ? wrote : r;
+	return r >= 0 ? wrote : r;
 }
 
 static void setup_socket(ks_socket_t sock)

--- a/src/kws.c
+++ b/src/kws.c
@@ -1622,7 +1622,7 @@ KS_DECLARE(ks_ssize_t) kws_write_frame(kws_t *kws, kws_opcode_t oc, const void *
 
 	raw_ret = kws_raw_write(kws, bp, (hlen + bytes));
 
-	if (raw_ret != (ks_ssize_t) (hlen + bytes)) {
+	if (raw_ret <= 0 || raw_ret != (ks_ssize_t) (hlen + bytes)) {
 		return raw_ret;
 	}
 

--- a/src/kws.c
+++ b/src/kws.c
@@ -615,7 +615,7 @@ KS_DECLARE(ks_ssize_t) kws_raw_write(kws_t *kws, void *data, ks_size_t bytes)
 			r = ssl_err * -1;
 		}
 
-		return r;
+		return r > 0 ? wrote : r;
 	}
 
 	do {
@@ -650,7 +650,7 @@ KS_DECLARE(ks_ssize_t) kws_raw_write(kws_t *kws, void *data, ks_size_t bytes)
 		//printf("wRITE FAIL: %s\n", strerror(errno));
 	//}
 
-	return wrote;
+	return r > 0 ? wrote : r;
 }
 
 static void setup_socket(ks_socket_t sock)

--- a/src/kws.c
+++ b/src/kws.c
@@ -650,7 +650,7 @@ KS_DECLARE(ks_ssize_t) kws_raw_write(kws_t *kws, void *data, ks_size_t bytes)
 		//printf("wRITE FAIL: %s\n", strerror(errno));
 	//}
 
-	return r;
+	return wrote;
 }
 
 static void setup_socket(ks_socket_t sock)


### PR DESCRIPTION
kws_raw_write should return the total number of bytes sent, not just the last fragment sent

Discussion with @andywolk concluded that we're still not comfortable with the condition and return here:
https://github.com/signalwire/libks/blob/master/src/kws.c#L1626

However, with the fix this will no longer be hit due to fragmented sending.  I am leaving it to Andrey to follow up on what they want to do about that code acting as if it can handle partial returns when it cannot happen.