### PR TITLE
[GHA] Use `ubuntu-24.04-arm` runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,9 +33,9 @@ jobs:
           - name: amd64
             runner: ubuntu-latest
           - name: arm32v7
-            runner: ubuntu-latest
+            runner: ubuntu-24.04-arm
           - name: arm64v8
-            runner: ubuntu-latest
+            runner: ubuntu-24.04-arm
     with:
       RUNNER: ${{ matrix.platform.runner }}
       ARTIFACTS_PATTERN: '.*\.(deb)$'
@@ -74,9 +74,9 @@ jobs:
           - name: amd64
             runner: ubuntu-latest
           - name: arm32v7
-            runner: ubuntu-latest
+            runner: ubuntu-24.04-arm
           - name: arm64v8
-            runner: ubuntu-latest
+            runner: ubuntu-24.04-arm
         release:
           - release
           - unstable


### PR DESCRIPTION
According to https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/ new Arm runners have been added as public preview, this PR tests this runner.