### PR TITLE
[GHA] Skip mirror and meta jobs on public forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
 
   deb-mirror:
     name: "DEB-MIRROR"
-    if: ${{ github.event_name != 'pull_request' }}
+    if: ${{ github.event_name != 'pull_request' && github.repository == 'signalwire/libks' }}
     needs:
       - deb
     runs-on: ubuntu-latest
@@ -104,7 +104,7 @@ jobs:
 
   meta:
     name: "Publish build data to meta-repo"
-    if: ${{ github.event_name != 'pull_request' }}
+    if: ${{ github.event_name != 'pull_request' && github.repository == 'signalwire/libks' }}
     needs:
       - deb
       - deb-mirror


### PR DESCRIPTION
## Description

Don't run publish related jobs on repository forks, keeps CI clean for contributors

## Type of Change

- [x] CI
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code cleanup / refactor

## Related Issues

<!-- Link any related issues: Fixes #123 or Relates to #456 -->

## Testing

<!-- How did you test your changes? -->

- [ ] Added/updated unit tests
- [ ] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

## Checklist

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [ ] My code follows the project's style guidelines
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] All existing tests pass

## Additional Notes

<!-- Any other context about the PR -->
